### PR TITLE
Hyphenate a word, that contains dash.

### DIFF
--- a/MiKTeX/preamble.tex
+++ b/MiKTeX/preamble.tex
@@ -409,3 +409,8 @@
 
 % Для включения pdf документов в результирующий файл
 \usepackage{pdfpages}
+
+% Зачем: Переносы в словах с тире.
+% Тире в словае заменяем на \hyph: аппаратно\hyphпрограммный.
+% https://stackoverflow.com/questions/2193307/how-to-get-latex-to-hyphenate-a-word-that-contains-a-dash#
+\def\hyph{-\penalty0\hskip0pt\relax}


### PR DESCRIPTION
Слова с тире не переносятся, фикс.
