### PR TITLE
Использовать scalable-cyrfonts-tex вместо PSCyr

### DIFF
--- a/MiKTeX/preamble.tex
+++ b/MiKTeX/preamble.tex
@@ -3,11 +3,19 @@
 % Примечание: параметр draft помечает строки, вышедшие за границы страницы, прямоугольником, в фильной версии его нужно удалить.
 \documentclass[a4paper,14pt,russian,oneside,final]{extreport}
 
-% Зачем: Улучшает отображение русских шрифтов.
+% Зачем: Предоставляет проприетарный Times New Roman.
+% ОБНОВЛЕНИЕ: лучше использовать scalable-cyrfonts-tex: меньше проблем с установкой
 % Из руководства к PSCyr: "Во избежание проблем пакет PSCyr должен загружаться перед пакета-ми inputenc и babel".
 % Примечание: Требует шаманства при установке, инструкция http://plumbum-blog.blogspot.com/2010/06/miktex-28-pscyr-04d.html
 % http://blog.harrix.org/?p=444
+% надо закомментировать это, чтобы использовать scalable-cyrfonts-tex:
 \usepackage{pscyr}
+
+% Зачем: Предоставляет свободный Times New Roman.
+% Шрифт идёт вместе с пакетом scalable-cyrfonts-tex в Ubuntu/Debian
+% раскомментировать, чтобы использовать scalable-cyrfonts-tex:
+%\usefont{T2A}{ftm}{m}{sl}
+
 
 % Зачем: Установка кодировки исходных файлов.
 \usepackage[utf8]{inputenc}

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 * Рекомендуемые справочные пособия по вопросам связанным с LaTeX: [Bing](http://bing.com/?mkt=en-us), [Google](http://google.com), [Yandex](http://ya.ru) и книги.
 * Рекомендуемая программа для ведения библиографической базы данных: [JabRef](http://jabref.sourceforge.net/)
 * Инструкция по установке русского Times New Roman из пакета pscyr находится [здесь](http://plumbum-blog.blogspot.com/2010/06/miktex-28-pscyr-04d.html)
+* Если возникли **проблемы с pscyr**, то можно переключиться на использование **scalable-cyrfonts-tex**, с которым также могут быть проблемы при установке, но их **проще решить** (см. 
+[Wiki→Возникающие-ошибки](https://github.com/mstyura/bsuir-diploma-latex/wiki/Возникающие-ошибки#scalable-cyrfonts-tex-on-ubuntu))
 
 # Пример
 В качестве примера приведены моя пояснительная записка к дипломному проекту [example_diploma.pdf](https://github.com/mstyura/bsuir-diploma-latex/blob/master/example_diploma.pdf)


### PR DESCRIPTION
Предлагаю обсудить возможность использования стандартного пакета со свободными виндоподобными шрифтами scalable-cyrfonts-tex вместо PSCyr.

Плюсы scalable-cyrfonts-tex:
+ доступны из стандартного пакетного менеджера (в тех ОС, где есть пакетный менеджер :))
+ значительно меньше плясок с бубном при установке (есть надежда, что в будущем можно обойтись вообще без плясок)
+ по некоторым заявлениям, начертания букв в scalable-cyrfonts-tex гораздо более аутентичные, в сравнении с PSCyr

Минусы:
- немного неестественно смотрится буква "У"
- возможные проблемы с установкой под Windows и OS X (нужно проверять)