### PR TITLE
Использовать по умолчанию scalable-cyrfonts-tex как шрифт Times New Roman

### DIFF
--- a/MiKTeX/fonts_linux.tex
+++ b/MiKTeX/fonts_linux.tex
@@ -1,0 +1,13 @@
+% Зачем: Выбор внутренней TeX кодировки.
+\usepackage[T2A]{fontenc}
+
+% Зачем: Предоставляет свободный Times New Roman.
+% Шрифт идёт вместе с пакетом scalable-cyrfonts-tex в Ubuntu/Debian
+
+% пакет scalable-cyrfonts-tex может конфликтовать с texlive-fonts-extra в Ubuntu
+% решение: Для себя я решил эту проблему так: пересобрал пакет scalable-cyrfonts-tex, изменив его имя. Решение топорное, но работает. Желающие могут скачать мой пакет здесь:
+% https://yadi.sk/d/GW2PhDgEcJH7m
+% Установка:
+% dpkg -i scalable-cyrfonts-tex-shurph_4.16_all.deb
+
+\usefont{T2A}{ftm}{m}{sl}

--- a/MiKTeX/fonts_windows.tex
+++ b/MiKTeX/fonts_windows.tex
@@ -1,0 +1,10 @@
+% Зачем: Предоставляет проприетарный Times New Roman.
+% ОБНОВЛЕНИЕ: лучше использовать scalable-cyrfonts-tex: меньше проблем с установкой
+% Из руководства к PSCyr: "Во избежание проблем пакет PSCyr должен загружаться перед пакета-ми inputenc и babel".
+% Примечание: Требует шаманства при установке, инструкция http://plumbum-blog.blogspot.com/2010/06/miktex-28-pscyr-04d.html
+% http://blog.harrix.org/?p=444
+\usepackage{pscyr}
+
+% Зачем: Выбор внутренней TeX кодировки.
+\usepackage[T2A]{fontenc}
+

--- a/MiKTeX/preamble.tex
+++ b/MiKTeX/preamble.tex
@@ -3,28 +3,20 @@
 % Примечание: параметр draft помечает строки, вышедшие за границы страницы, прямоугольником, в фильной версии его нужно удалить.
 \documentclass[a4paper,14pt,russian,oneside,final]{extreport}
 
-% Зачем: Предоставляет проприетарный Times New Roman.
-% ОБНОВЛЕНИЕ: лучше использовать scalable-cyrfonts-tex: меньше проблем с установкой
-% Из руководства к PSCyr: "Во избежание проблем пакет PSCyr должен загружаться перед пакета-ми inputenc и babel".
-% Примечание: Требует шаманства при установке, инструкция http://plumbum-blog.blogspot.com/2010/06/miktex-28-pscyr-04d.html
-% http://blog.harrix.org/?p=444
-% надо закомментировать это, чтобы использовать scalable-cyrfonts-tex:
-\usepackage{pscyr}
+% Зачем: Настройка Times New Roman.
+% Рекомендовано для Windows (нужен PSCyr, подробности см. в fonts_windows.tex)
+% раскомментировать, чтобы использовать:
+%\input{fonts_windows}% не забудьте закомментировать \input{fonts_linux}
 
-% Зачем: Предоставляет свободный Times New Roman.
-% Шрифт идёт вместе с пакетом scalable-cyrfonts-tex в Ubuntu/Debian
-% раскомментировать, чтобы использовать scalable-cyrfonts-tex:
-%\usefont{T2A}{ftm}{m}{sl}
-
+% Рекомендовано для Linux (нужен scalable-cyrfonts-tex, подробности см. в fonts_linux.tex)
+% раскомментировать, чтобы использовать:
+\input{fonts_linux}% не забудьте закомментировать \input{fonts_windows}
 
 % Зачем: Установка кодировки исходных файлов.
 \usepackage[utf8]{inputenc}
 
 % Зачем: Делает результирующий PDF "searchable and copyable".
 \usepackage{cmap}
-
-% Зачем: Выбор внутренней TeX кодировки.
-\usepackage[T2A]{fontenc}
 
 % Зачем: Чтобы можно было использовать русские буквы в формулах, но в случае использования предупреждать об этом.
 \usepackage[warn]{mathtext}

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@
 
 ### Windows (MiKTeX)
 - см. выше список рекомендаций
+- раскомментировать строку `\input{fonts_windows}` в файле `preamble.tex` (и закомментировать строку `\input{fonts_linux}`)
 
 
 # Пример


### PR DESCRIPTION
Предлагаю, всё-таки, использовать по умолчанию scalable-cyrfonts-tex для кириллических шрифтов.

Его проще устанавливать и настраивать (по крайней мере, под линуксами).

И я буду делать бокс для vagrant'а с расчётом на scalable-cyrfonts-tex (т.к. не хочу возиться с pscyr)