### PR TITLE
СТП: перед и после "где" не должно быть конских отступов

### DIFF
--- a/MiKTeX/preamble.tex
+++ b/MiKTeX/preamble.tex
@@ -228,18 +228,16 @@
 \newlength{\lengthWordWhere}
 \settowidth{\lengthWordWhere}{где}
 \newenvironment{explanationx}
-    {
+    {%
     %%% Следующие строки определяют специфические требования разных редакций стандартов. Раскоменнтируйте нужную строку
     %% стандартный абзац, СТП-01 2010
     %\begin{itemize}[leftmargin=0cm, itemindent=\parindent + \lengthWordWhere + \labelsep, labelsep=\labelsep]
-
     %% без отступа, СТП-01 2013
-    \begin{itemize}[leftmargin=0cm, itemindent=\lengthWordWhere + \labelsep , labelsep=\labelsep]
-
-    \renewcommand\labelitemi{}
+    \begin{itemize}[leftmargin=0cm, itemindent=\lengthWordWhere + \labelsep , labelsep=\labelsep]%
+    \renewcommand\labelitemi{}%
     }
-    {
-    \\[\parsep]
+    {%
+    %\\[\parsep]
     \end{itemize}
     }
 


### PR DESCRIPTION
Конские отступы должны быть перед и после displaymath и equation, но не
понятно, как их правильно сделать (про отступы в формулах есть issue #15)