### PR TITLE
Автоматическая пересборка diploma_report.pdf при изменении *.tex файлов

### DIFF
--- a/MiKTeX/Makefile
+++ b/MiKTeX/Makefile
@@ -23,8 +23,11 @@ publish_to_dropbox: all
 	cp $(DIPLOMA_REPORT_PDF).pdf $(DROPBOX_PUBLIC)/$(DIPLOMA_REPORT_PDF).pdf
 	cp $(PRACTICE_REPORT_PDF).pdf $(DROPBOX_PUBLIC)/$(PRACTICE_REPORT_PDF).pdf
 
+watch: *.tex
+	latexmk -pdf -pdflatex="$(PDFLATEX)" -pvc $(DIPLOMA_REPORT_PDF)
+
 fast: *.tex
-	latexmk -pdf -pdflatex="pdflatex" $(DIPLOMA_REPORT_PDF)
+	latexmk -pdf -pdflatex="$(PDFLATEX)" $(DIPLOMA_REPORT_PDF)
 	mv $(DIPLOMA_REPORT_PDF).pdf $(DIPLOMA_REPORT_PDF)-`date +'%m-%d-%H-%M-%S'`.pdf
 
 fastcheck: *.tex


### PR DESCRIPTION
`latexmk` умеет из коробки следить за изменениями и при необходимости пересобирать pdf (флаг `-pvc`). Данный PR добавляет в `Makefile` цель `watch` которая использует данный функционал для сборки diploma_report.pdf.
Также сделан небольшой фикс с заменой харкода в флаге `-pdflatex` на переменную используемую в большинстве задач в `Makefile`